### PR TITLE
Feature: JSON nested attributes

### DIFF
--- a/Pod/Tests/Tests.m
+++ b/Pod/Tests/Tests.m
@@ -9,41 +9,6 @@
 
 @implementation PodTests
 
-- (void)testRailsNestedAttributesA
-{
-    NSDictionary *dictionary = @{@"first_name" : @"Chris",
-                                 @"contacts[0].name" : @"Tim",
-                                 @"contacts[0].phone_number" : @"444444",
-                                 @"contacts[1].name" : @"Johannes",
-                                 @"contacts[1].phone_number" : @"555555"};
-
-    NSDictionary *contactFirst = @{@"0" : @{@"name" : @"Tim",
-                                            @"phone_number" : @"444444"}};
-
-    NSDictionary *contactSecond = @{@"1" : @{@"name" : @"Johannes",
-                                             @"phone_number" : @"555555"}};
-
-    NSDictionary *resultDictionary = @{@"first_name" : @"Chris",
-                                       @"contacts_attributes" : @[contactFirst, contactSecond]};
-
-    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
-}
-
-- (void)testRailsNestedAttributesB
-{
-    NSDictionary *dictionary = @{@"contacts[0].id" : @0,
-                                 @"notes[0].id" : @0};
-
-    NSDictionary *contact = @{@"0" : @{@"id" : @0}};
-
-    NSDictionary *note = @{@"0" : @{@"id" : @0}};
-
-    NSDictionary *resultDictionary = @{@"contacts_attributes" : @[contact],
-                                       @"notes_attributes" : @[note]};
-
-    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
-}
-
 - (void)testJSONNestedAttributesA
 {
     NSDictionary *dictionary = @{@"first_name" : @"Chris",
@@ -77,6 +42,41 @@
                                        @"notes" : @[note]};
 
     XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
+}
+
+- (void)testRailsNestedAttributesA
+{
+    NSDictionary *dictionary = @{@"first_name" : @"Chris",
+                                 @"contacts[0].name" : @"Tim",
+                                 @"contacts[0].phone_number" : @"444444",
+                                 @"contacts[1].name" : @"Johannes",
+                                 @"contacts[1].phone_number" : @"555555"};
+
+    NSDictionary *contactFirst = @{@"0" : @{@"name" : @"Tim",
+                                            @"phone_number" : @"444444"}};
+
+    NSDictionary *contactSecond = @{@"1" : @{@"name" : @"Johannes",
+                                             @"phone_number" : @"555555"}};
+
+    NSDictionary *resultDictionary = @{@"first_name" : @"Chris",
+                                       @"contacts_attributes" : @[contactFirst, contactSecond]};
+
+    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
+}
+
+- (void)testRailsNestedAttributesB
+{
+    NSDictionary *dictionary = @{@"contacts[0].id" : @0,
+                                 @"notes[0].id" : @0};
+
+    NSDictionary *contact = @{@"0" : @{@"id" : @0}};
+
+    NSDictionary *note = @{@"0" : @{@"id" : @0}};
+
+    NSDictionary *resultDictionary = @{@"contacts_attributes" : @[contact],
+                                       @"notes_attributes" : @[note]};
+
+    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
 }
 
 @end

--- a/Pod/Tests/Tests.m
+++ b/Pod/Tests/Tests.m
@@ -9,7 +9,7 @@
 
 @implementation PodTests
 
-- (void)testNestifyA
+- (void)testRailsNestedAttributesA
 {
     NSDictionary *dictionary = @{@"first_name" : @"Chris",
                                  @"contacts[0].name" : @"Tim",
@@ -26,10 +26,10 @@
     NSDictionary *resultDictionary = @{@"first_name" : @"Chris",
                                        @"contacts_attributes" : @[contactFirst, contactSecond]};
 
-    XCTAssertEqualObjects([dictionary hyp_nestify], resultDictionary);
+    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
 }
 
-- (void)testNestifyB
+- (void)testRailsNestedAttributesB
 {
     NSDictionary *dictionary = @{@"contacts[0].id" : @0,
                                  @"notes[0].id" : @0};
@@ -41,7 +41,42 @@
     NSDictionary *resultDictionary = @{@"contacts_attributes" : @[contact],
                                        @"notes_attributes" : @[note]};
 
-    XCTAssertEqualObjects([dictionary hyp_nestify], resultDictionary);
+    XCTAssertEqualObjects([dictionary hyp_railsNestedAttributes], resultDictionary);
+}
+
+- (void)testJSONNestedAttributesA
+{
+    NSDictionary *dictionary = @{@"first_name" : @"Chris",
+                                 @"contacts[0].name" : @"Tim",
+                                 @"contacts[0].phone_number" : @"444444",
+                                 @"contacts[1].name" : @"Johannes",
+                                 @"contacts[1].phone_number" : @"555555"};
+
+    NSDictionary *contactFirst = @{@"name" : @"Tim",
+                                   @"phone_number" : @"444444"};
+
+    NSDictionary *contactSecond = @{@"name" : @"Johannes",
+                                    @"phone_number" : @"555555"};
+
+    NSDictionary *resultDictionary = @{@"first_name" : @"Chris",
+                                       @"contacts" : @[contactFirst, contactSecond]};
+
+    XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
+}
+
+- (void)testJSONNestedAttributesB
+{
+    NSDictionary *dictionary = @{@"contacts[0].id" : @0,
+                                 @"notes[0].id" : @0};
+
+    NSDictionary *contact = @{@"id" : @0};
+
+    NSDictionary *note = @{@"id" : @0};
+
+    NSDictionary *resultDictionary = @{@"contacts" : @[contact],
+                                       @"notes" : @[note]};
+
+    XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This is a category on NSDictionary that converts the flat relationships in a dictionary to a nested attributes format.
 
+## JSON Nested Attributes
+
 ```objc
 NSDictionary *dictionary = @{@"first_name" : @"Chris",
                              @"contacts[0].name" : @"Tim",
@@ -15,7 +17,34 @@ NSDictionary *dictionary = @{@"first_name" : @"Chris",
                              @"contacts[1].phone_number" : @"555555"};
 
 
-NSDictionary *nestedAttributesDictionary = [dictionary hyp_nestify];
+NSDictionary *nestedAttributesDictionary = [dictionary hyp_JSONNestedAttributes];
+```
+
+```json
+"first_name": "Chris",
+"contacts": [
+  {
+    "name": "Tim",
+    "phone_number": "444444"
+  },
+  {
+    "name": "Johannes",
+    "phone_number": "555555"
+  }
+]
+```
+
+## Rails Nested Attributes
+
+```objc
+NSDictionary *dictionary = @{@"first_name" : @"Chris",
+                             @"contacts[0].name" : @"Tim",
+                             @"contacts[0].phone_number" : @"444444",
+                             @"contacts[1].name" : @"Johannes",
+                             @"contacts[1].phone_number" : @"555555"};
+
+
+NSDictionary *nestedAttributesDictionary = [dictionary hyp_railsNestedAttributes];
 ```
 
 ```json
@@ -32,12 +61,6 @@ NSDictionary *nestedAttributesDictionary = [dictionary hyp_nestify];
     }
   }
 ]
-```
-
-## Usage
-
-```objc
-- (NSDictionary *)hyp_nestify;
 ```
 
 ## Installation

--- a/Source/NSDictionary+HYPNestedAttributes.h
+++ b/Source/NSDictionary+HYPNestedAttributes.h
@@ -2,6 +2,8 @@
 
 @interface NSDictionary (HYPNestedAttributes)
 
-- (NSDictionary *)hyp_nestify;
+- (NSDictionary *)hyp_railsNestedAttributes;
+
+- (NSDictionary *)hyp_JSONNestedAttributes;
 
 @end

--- a/Source/NSDictionary+HYPNestedAttributes.h
+++ b/Source/NSDictionary+HYPNestedAttributes.h
@@ -2,8 +2,8 @@
 
 @interface NSDictionary (HYPNestedAttributes)
 
-- (NSDictionary *)hyp_railsNestedAttributes;
-
 - (NSDictionary *)hyp_JSONNestedAttributes;
+
+- (NSDictionary *)hyp_railsNestedAttributes;
 
 @end

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -6,9 +6,24 @@
 
 static NSString * const HYPNestedAttributesRailsKey = @"_attributes";
 
+typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
+    HYPJSONNestedAttributesType,
+    HYPRailsNestedAttributesType
+};
+
 @implementation NSDictionary (HYPNestedAttributes)
 
+- (NSDictionary *)hyp_JSONNestedAttributes
+{
+    return [self nestedAttributes:HYPJSONNestedAttributesType];
+}
+
 - (NSDictionary *)hyp_railsNestedAttributes
+{
+    return [self nestedAttributes:HYPRailsNestedAttributesType];
+}
+
+- (NSDictionary *)nestedAttributes:(HYPNestedAttributesType)type
 {
     NSMutableDictionary *parsedIndexes = [NSMutableDictionary new];
     NSMutableArray *relationIndexes = [NSMutableArray new];
@@ -17,34 +32,16 @@ static NSString * const HYPNestedAttributesRailsKey = @"_attributes";
     for (NSString *key in sortedKeys) {
         HYPParsedRelationship *parsed = [key hyp_parseRelationship];
         if (parsed.toMany) {
-            NSString *indexString = [parsed.index stringValue];
-
-            __block NSMutableDictionary *foundDictionary;
-            __block BOOL found = NO;
-            for (NSDictionary *currentChildDictionary in relationIndexes) {
-                NSString *currentIndexString = currentChildDictionary.allKeys.firstObject;
-                if ([currentIndexString isEqualToString:indexString]) {
-                    foundDictionary = [currentChildDictionary[indexString] mutableCopy];
-                    found = YES;
-                }
+            if (type == HYPJSONNestedAttributesType) {
+                relationIndexes = [[self JSONProcessKeyRelationIndexes:relationIndexes
+                                                                parsed:parsed
+                                                                   key:key] mutableCopy];
+                parsedIndexes[parsed.relationship] = relationIndexes;
+            } else if (type == HYPRailsNestedAttributesType) {
+                relationIndexes = [[self railsProcessKeyRelationIndexes:relationIndexes parsed:parsed key:key] mutableCopy];
+                NSString *attributesKey = [NSString stringWithFormat:@"%@%@", parsed.relationship, HYPNestedAttributesRailsKey];
+                parsedIndexes[attributesKey] = relationIndexes;
             }
-
-            if (!foundDictionary) {
-                foundDictionary = [NSMutableDictionary new];
-            }
-
-            NSString *attributeKey = [self valueForKey:key];
-            foundDictionary[parsed.attribute] = attributeKey;
-
-            NSDictionary *childDictionary = @{indexString : foundDictionary};
-            if (found) {
-                [relationIndexes replaceObjectAtIndex:[parsed.index integerValue] withObject:childDictionary];
-            } else {
-                [relationIndexes addObject:childDictionary];
-            }
-
-            NSString *attributesKey = [NSString stringWithFormat:@"%@%@", parsed.relationship, HYPNestedAttributesRailsKey];
-            parsedIndexes[attributesKey] = relationIndexes;
         } else {
             NSString *attributeKey = [self valueForKey:key];
             parsedIndexes[parsed.attribute] = attributeKey;
@@ -54,45 +51,62 @@ static NSString * const HYPNestedAttributesRailsKey = @"_attributes";
     return parsedIndexes;
 }
 
-- (NSDictionary *)hyp_JSONNestedAttributes
+- (NSArray *)railsProcessKeyRelationIndexes:(NSMutableArray *)relationIndexes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key
 {
-    NSMutableDictionary *parsedIndexes = [NSMutableDictionary new];
-    NSMutableArray *relationIndexes = [NSMutableArray new];
+    NSString *indexString = [parsed.index stringValue];
 
-    NSArray *sortedKeys = [[self allKeys] sortedArrayUsingSelector:@selector(compare:)];
-    for (NSString *key in sortedKeys) {
-        HYPParsedRelationship *parsed = [key hyp_parseRelationship];
-        if (parsed.toMany) {
-            __block NSMutableDictionary *foundDictionary;
-            __block BOOL found = NO;
-            [relationIndexes enumerateObjectsUsingBlock:^(NSDictionary *currentChildDictionary, NSUInteger idx, BOOL *stop) {
-                if ([parsed.index integerValue] == idx) {
-                    foundDictionary = [currentChildDictionary mutableCopy];
-                    found = YES;
-                }
-            }];
-
-            if (!foundDictionary) {
-                foundDictionary = [NSMutableDictionary new];
-            }
-
-            NSString *attributeKey = [self valueForKey:key];
-            foundDictionary[parsed.attribute] = attributeKey;
-
-            if (found) {
-                [relationIndexes replaceObjectAtIndex:[parsed.index integerValue] withObject:foundDictionary];
-            } else {
-                [relationIndexes addObject:foundDictionary];
-            }
-
-            parsedIndexes[parsed.relationship] = relationIndexes;
-        } else {
-            NSString *attributeKey = [self valueForKey:key];
-            parsedIndexes[parsed.attribute] = attributeKey;
+    __block NSMutableDictionary *foundDictionary;
+    __block BOOL found = NO;
+    for (NSDictionary *currentChildDictionary in relationIndexes) {
+        NSString *currentIndexString = currentChildDictionary.allKeys.firstObject;
+        if ([currentIndexString isEqualToString:indexString]) {
+            foundDictionary = [currentChildDictionary[indexString] mutableCopy];
+            found = YES;
         }
     }
 
-    return parsedIndexes;
+    if (!foundDictionary) {
+        foundDictionary = [NSMutableDictionary new];
+    }
+
+    NSString *attributeKey = [self valueForKey:key];
+    foundDictionary[parsed.attribute] = attributeKey;
+
+    NSDictionary *childDictionary = @{indexString : foundDictionary};
+    if (found) {
+        [relationIndexes replaceObjectAtIndex:[parsed.index integerValue] withObject:childDictionary];
+    } else {
+        [relationIndexes addObject:childDictionary];
+    }
+
+    return relationIndexes;
+}
+
+- (NSArray *)JSONProcessKeyRelationIndexes:(NSMutableArray *)relationIndexes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key
+{
+    __block NSMutableDictionary *foundDictionary;
+    __block BOOL found = NO;
+    [relationIndexes enumerateObjectsUsingBlock:^(NSDictionary *currentChildDictionary, NSUInteger idx, BOOL *stop) {
+        if ([parsed.index integerValue] == idx) {
+            foundDictionary = [currentChildDictionary mutableCopy];
+            found = YES;
+        }
+    }];
+
+    if (!foundDictionary) {
+        foundDictionary = [NSMutableDictionary new];
+    }
+
+    NSString *attributeKey = [self valueForKey:key];
+    foundDictionary[parsed.attribute] = attributeKey;
+
+    if (found) {
+        [relationIndexes replaceObjectAtIndex:[parsed.index integerValue] withObject:foundDictionary];
+    } else {
+        [relationIndexes addObject:foundDictionary];
+    }
+
+    return relationIndexes;
 }
 
 @end

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -4,11 +4,11 @@
 
 #import "NSString+HYPRelationshipParser.h"
 
-static NSString * const HYPNestedAttributesKey = @"_attributes";
+static NSString * const HYPNestedAttributesRailsKey = @"_attributes";
 
 @implementation NSDictionary (HYPNestedAttributes)
 
-- (NSDictionary *)hyp_nestify
+- (NSDictionary *)hyp_railsNestedAttributes
 {
     NSMutableDictionary *parsedIndexes = [NSMutableDictionary new];
     NSMutableArray *relationIndexes = [NSMutableArray new];
@@ -43,8 +43,49 @@ static NSString * const HYPNestedAttributesKey = @"_attributes";
                 [relationIndexes addObject:childDictionary];
             }
 
-            NSString *attributesKey = [NSString stringWithFormat:@"%@%@", parsed.relationship, HYPNestedAttributesKey];
+            NSString *attributesKey = [NSString stringWithFormat:@"%@%@", parsed.relationship, HYPNestedAttributesRailsKey];
             parsedIndexes[attributesKey] = relationIndexes;
+        } else {
+            NSString *attributeKey = [self valueForKey:key];
+            parsedIndexes[parsed.attribute] = attributeKey;
+        }
+    }
+
+    return parsedIndexes;
+}
+
+- (NSDictionary *)hyp_JSONNestedAttributes
+{
+    NSMutableDictionary *parsedIndexes = [NSMutableDictionary new];
+    NSMutableArray *relationIndexes = [NSMutableArray new];
+
+    NSArray *sortedKeys = [[self allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    for (NSString *key in sortedKeys) {
+        HYPParsedRelationship *parsed = [key hyp_parseRelationship];
+        if (parsed.toMany) {
+            __block NSMutableDictionary *foundDictionary;
+            __block BOOL found = NO;
+            [relationIndexes enumerateObjectsUsingBlock:^(NSDictionary *currentChildDictionary, NSUInteger idx, BOOL *stop) {
+                if ([parsed.index integerValue] == idx) {
+                    foundDictionary = [currentChildDictionary mutableCopy];
+                    found = YES;
+                }
+            }];
+
+            if (!foundDictionary) {
+                foundDictionary = [NSMutableDictionary new];
+            }
+
+            NSString *attributeKey = [self valueForKey:key];
+            foundDictionary[parsed.attribute] = attributeKey;
+
+            if (found) {
+                [relationIndexes replaceObjectAtIndex:[parsed.index integerValue] withObject:foundDictionary];
+            } else {
+                [relationIndexes addObject:foundDictionary];
+            }
+
+            parsedIndexes[parsed.relationship] = relationIndexes;
         } else {
             NSString *attributeKey = [self valueForKey:key];
             parsedIndexes[parsed.attribute] = attributeKey;


### PR DESCRIPTION
Before we were supporting only [Active Record Nested Attributes](http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html).

This pull request adds support for JSON styled nested attributes.
## JSON Nested Attributes

``` objc
NSDictionary *dictionary = @{@"first_name" : @"Chris",
                             @"contacts[0].name" : @"Tim",
                             @"contacts[0].phone_number" : @"444444",
                             @"contacts[1].name" : @"Johannes",
                             @"contacts[1].phone_number" : @"555555"};

NSDictionary *nestedAttributesDictionary = [dictionary hyp_JSONNestedAttributes];
```

``` json
"first_name": "Chris",
"contacts": [
  {
    "name": "Tim",
    "phone_number": "444444"
  },
  {
    "name": "Johannes",
    "phone_number": "555555"
  }
]
```
