### PR TITLE
Bug in JSONNestedAttributes 

### DIFF
--- a/Pod/Tests/Tests.m
+++ b/Pod/Tests/Tests.m
@@ -68,6 +68,19 @@
     XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
 }
 
+- (void)testJSONNestedAttributesD
+{
+    NSDictionary *dictionary = @{@"companies[1].name" : @"Google",
+                                 @"companies[1].phone_number" : @"4555666"};
+
+    NSDictionary *company = @{@"name" : @"Google",
+                              @"phone_number" : @"4555666"};
+
+    NSDictionary *resultDictionary = @{@"contacts" : @[company]};
+
+    XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
+}
+
 - (void)testRailsNestedAttributesA
 {
     NSDictionary *dictionary = @{@"first_name" : @"Chris",
@@ -77,9 +90,9 @@
                                  @"contacts[1].phone_number" : @"555555"};
 
     NSDictionary *contacts = @{@"0" : @{@"name" : @"Tim",
-                                            @"phone_number" : @"444444"},
-                                   @"1" : @{@"name" : @"Johannes",
-                                            @"phone_number" : @"555555"}};
+                                        @"phone_number" : @"444444"},
+                               @"1" : @{@"name" : @"Johannes",
+                                        @"phone_number" : @"555555"}};
 
     NSDictionary *resultDictionary = @{@"first_name" : @"Chris",
                                        @"contacts_attributes" : contacts};

--- a/Pod/Tests/Tests.m
+++ b/Pod/Tests/Tests.m
@@ -76,7 +76,7 @@
     NSDictionary *company = @{@"name" : @"Google",
                               @"phone_number" : @"4555666"};
 
-    NSDictionary *resultDictionary = @{@"contacts" : @[company]};
+    NSDictionary *resultDictionary = @{@"companies" : @[company]};
 
     XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
 }

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -80,7 +80,10 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
     return attributesDictionary;
 }
 
-- (NSArray *)JSONProcessNestedAttributes:(NSArray *)nestedAttributes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key index:(NSInteger)index
+- (NSArray *)JSONProcessNestedAttributes:(NSArray *)nestedAttributes
+                                  parsed:(HYPParsedRelationship *)parsed
+                                     key:(NSString *)key
+                                   index:(NSInteger)index
 {
     NSMutableArray *processedNestedAttributes = [nestedAttributes mutableCopy];
     NSMutableDictionary *foundDictionary;
@@ -104,7 +107,9 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
     return [processedNestedAttributes copy];
 }
 
-- (NSDictionary *)railsProcessNestedAttributes:(NSMutableDictionary *)nestedAttributes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key
+- (NSDictionary *)railsProcessNestedAttributes:(NSMutableDictionary *)nestedAttributes
+                                        parsed:(HYPParsedRelationship *)parsed
+                                           key:(NSString *)key
 {
     NSMutableDictionary *processedNestedAttributes = [nestedAttributes mutableCopy];
     NSString *indexString = [parsed.index stringValue];

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -38,20 +38,22 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
         HYPParsedRelationship *parsed = [key hyp_parseRelationship];
         if (parsed.toMany) {
             if (type == HYPJSONNestedAttributesType) {
-                HYPParsedRelationship *relationshipPrefixParsed = [key hyp_parseRelationship];
-                relationshipPrefixParsed.attribute = nil;
-                NSString *relationshipPrefix = [relationshipPrefixParsed key];
-                if (currentRelationIndex &&
-                    ![currentRelationIndex isEqualToString:relationshipPrefix]) {
+                HYPParsedRelationship *parsedRelationshipPrefix = [key hyp_parseRelationship];
+                parsedRelationshipPrefix.attribute = nil;
+                NSString *relationshipPrefix = [parsedRelationshipPrefix key];
+                BOOL hasTheSameRelationshipPrefix = (currentRelationIndex &&
+                                                     ![currentRelationIndex isEqualToString:relationshipPrefix]);
+                if (hasTheSameRelationshipPrefix) {
                     index++;
                 }
 
-                if (currentRelation &&
-                    ![currentRelation isEqualToString:relationshipPrefixParsed.relationship]) {
+                BOOL hasTheSameRelationship = (currentRelation &&
+                                               ![currentRelation isEqualToString:parsedRelationshipPrefix.relationship]);
+                if (hasTheSameRelationship) {
                     index = 0;
                 }
 
-                currentRelation = relationshipPrefixParsed.relationship;
+                currentRelation = parsedRelationshipPrefix.relationship;
                 currentRelationIndex = relationshipPrefix;
 
                 nestedArrayAttributes = attributesDictionary[parsed.relationship] ?: [NSMutableArray new];

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -84,23 +84,18 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
 {
     NSMutableArray *processedNestedAttributes = [nestedAttributes mutableCopy];
     NSMutableDictionary *foundDictionary;
-    BOOL found = YES;
 
-    BOOL isExistingRelationItem = (nestedAttributes.count > index);
-    if (isExistingRelationItem) {
+    BOOL isExistingRelationshipItem = (nestedAttributes.count > index);
+    if (isExistingRelationshipItem) {
         foundDictionary = [[nestedAttributes objectAtIndex:index] mutableCopy];
-    }
-
-
-    if (!foundDictionary) {
+    } else {
         foundDictionary = [NSMutableDictionary new];
-        found = NO;
     }
 
     NSString *attributeKey = [self valueForKey:key];
     foundDictionary[parsed.attribute] = attributeKey;
 
-    if (found) {
+    if (isExistingRelationshipItem) {
         [processedNestedAttributes replaceObjectAtIndex:index withObject:foundDictionary];
     } else {
         [processedNestedAttributes addObject:foundDictionary];

--- a/Source/NSDictionary+HYPNestedAttributes.m
+++ b/Source/NSDictionary+HYPNestedAttributes.m
@@ -54,29 +54,11 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
                 currentRelation = relationshipPrefixParsed.relationship;
                 currentRelationIndex = relationshipPrefix;
 
-                nestedArrayAttributes = attributesDictionary[parsed.relationship] ? [attributesDictionary[parsed.relationship] mutableCopy]: [NSMutableArray new];
-
-                NSMutableDictionary *foundDictionary;
-                BOOL found = YES;
-
-                BOOL isExistingRelationItem = (nestedArrayAttributes.count > index);
-                if (isExistingRelationItem) {
-                     foundDictionary = [[nestedArrayAttributes objectAtIndex:index] mutableCopy];
-                }
-
-                if (!foundDictionary) {
-                    foundDictionary = [NSMutableDictionary new];
-                    found = NO;
-                }
-
-                NSString *attributeKey = [self valueForKey:key];
-                foundDictionary[parsed.attribute] = attributeKey;
-
-                if (found) {
-                    [nestedArrayAttributes replaceObjectAtIndex:index withObject:foundDictionary];
-                } else {
-                    [nestedArrayAttributes addObject:foundDictionary];
-                }
+                nestedArrayAttributes = attributesDictionary[parsed.relationship] ?: [NSMutableArray new];
+                nestedArrayAttributes = [[self JSONProcessNestedAttributes:nestedArrayAttributes
+                                                                    parsed:parsed
+                                                                       key:key
+                                                                     index:index] mutableCopy];
 
                 attributesDictionary[parsed.relationship] = nestedArrayAttributes;
             } else if (type == HYPRailsNestedAttributesType) {
@@ -96,28 +78,28 @@ typedef NS_ENUM(NSInteger, HYPNestedAttributesType) {
     return attributesDictionary;
 }
 
-- (NSArray *)JSONProcessNestedAttributes:(NSArray *)nestedAttributes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key
+- (NSArray *)JSONProcessNestedAttributes:(NSArray *)nestedAttributes parsed:(HYPParsedRelationship *)parsed key:(NSString *)key index:(NSInteger)index
 {
     NSMutableArray *processedNestedAttributes = [nestedAttributes mutableCopy];
-    __block NSMutableDictionary *foundDictionary;
-    __block BOOL found = NO;
+    NSMutableDictionary *foundDictionary;
+    BOOL found = YES;
 
-    [nestedAttributes enumerateObjectsUsingBlock:^(NSDictionary *currentChildDictionary, NSUInteger idx, BOOL *stop) {
-        if ([parsed.index integerValue] == idx) {
-            foundDictionary = [currentChildDictionary mutableCopy];
-            found = YES;
-        }
-    }];
+    BOOL isExistingRelationItem = (nestedAttributes.count > index);
+    if (isExistingRelationItem) {
+        foundDictionary = [[nestedAttributes objectAtIndex:index] mutableCopy];
+    }
+
 
     if (!foundDictionary) {
         foundDictionary = [NSMutableDictionary new];
+        found = NO;
     }
 
     NSString *attributeKey = [self valueForKey:key];
     foundDictionary[parsed.attribute] = attributeKey;
 
     if (found) {
-        [processedNestedAttributes replaceObjectAtIndex:[parsed.index integerValue] withObject:foundDictionary];
+        [processedNestedAttributes replaceObjectAtIndex:index withObject:foundDictionary];
     } else {
         [processedNestedAttributes addObject:foundDictionary];
     }


### PR DESCRIPTION
`hyp_JSONNestedAttributes` is broken when the dictionary starts with 1 instead of 0.

``` objc
- (void)testJSONNestedAttributesD
{
    NSDictionary *dictionary = @{@"companies[1].name" : @"Google",
                                 @"companies[1].phone_number" : @"4555666"};

    NSDictionary *company = @{@"name" : @"Google",
                              @"phone_number" : @"4555666"};

    NSDictionary *resultDictionary = @{@"contacts" : @[company]};

    XCTAssertEqualObjects([dictionary hyp_JSONNestedAttributes], resultDictionary);
}
```
